### PR TITLE
feat: Enable user registration using wallet address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ const onClick = async () => {
 };
 ```
 
+## Configs
+
+If you want to change the message that is sent to the user, you can publish the config file and change it.
+
+```bash
+php artisan vendor:publish --provider="M1guelpf\Web3Login\Web3LoginServiceProvider" --tag="config"
+```
+
+This command will publish a config file to `config/web3.php` with the following options:
+
+```php
+[
+	// Message that is returned to the user in the /_web3/signature route
+	'message' => "Hey! Sign this message to prove you have access to this wallet. This won't cost you anything.\n\nSecurity code (you can ignore this): :nonce:",
+	// Routes created by this package
+    'routes' => ['login', 'register', 'link', 'signature'],
+]
+```
+
+For example, if you want to disable user registration through this package, you can remove `register` from `routes` config.
+
 ## Contributing
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.

--- a/config/web3.php
+++ b/config/web3.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laravel web3 login
+    |--------------------------------------------------------------------------
+    */
+
+    'message' => "Hey! Sign this message to prove you have access to this wallet. This won't cost you anything.\n\nSecurity code (you can ignore this): :nonce:",
+    'routes' => ['login', 'register', 'link', 'signature'],
+
+];

--- a/database/migrations/2021_03_21_154837_add_wallet_column_to_users_table.php
+++ b/database/migrations/2021_03_21_154837_add_wallet_column_to_users_table.php
@@ -15,6 +15,13 @@ class AddWalletColumnToUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->string('wallet')->nullable();
+            
+            $routes = config('web3.routes', []);
+            if (in_array('register', $routes)) {
+                $table->string('name')->nullable()->change();
+                $table->string('email')->nullable()->change();
+                $table->string('password')->nullable()->change();
+            }
         });
     }
 
@@ -27,6 +34,13 @@ class AddWalletColumnToUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('wallet');
+
+            $routes = config('web3.routes', []);
+            if (in_array('register', $routes)) {
+                $table->string('name')->change();
+                $table->string('email')->change();
+                $table->string('password')->change();
+            }
         });
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,21 @@ use Illuminate\Support\Facades\Route;
 use M1guelpf\Web3Login\Http\Controllers\Web3LoginController;
 
 Route::middleware('web')->as('web3')->prefix('_web3')->group(function () {
-    Route::get('signature', [Web3LoginController::class, 'signature'])->name('.signature');
-    Route::post('link', [Web3LoginController::class, 'link'])->middleware('auth')->name('.link');
-    Route::post('login', [Web3LoginController::class, 'login'])->middleware('guest')->name('.login');
+    $routes = config('web3.routes', ['signature', 'link', 'login']);
+
+    if (in_array('signature', $routes)) {
+        Route::get('signature', [Web3LoginController::class, 'signature'])->name('.signature');
+    }
+
+    if (in_array('link', $routes)) {
+        Route::post('link', [Web3LoginController::class, 'link'])->middleware('auth')->name('.link');
+    }
+
+    if (in_array('login', $routes)) {
+        Route::post('login', [Web3LoginController::class, 'login'])->middleware('guest')->name('.login');
+    }
+
+    if (in_array('register', $routes)) {
+        Route::post('register', [Web3LoginController::class, 'register'])->name('.register');
+    }
 });

--- a/src/Http/Controllers/Web3LoginController.php
+++ b/src/Http/Controllers/Web3LoginController.php
@@ -76,8 +76,13 @@ class Web3LoginController
             'address' => ['required', 'string', 'regex:/0x[a-fA-F0-9]{40}/m'],
             'signature' => ['required', 'string', 'regex:/^0x([A-Fa-f0-9]{130})$/'],
         ]);
+        $nonce = $request->session()->pull('nonce');
 
-        if (! Signature::verify($request->session()->pull('nonce'), $request->input('signature'), $request->input('address'))) {
+        if (!$nonce) {
+            throw ValidationException::withMessages(['signature' => 'Nonce not found. Please generate a sign message first.']);
+        }
+
+        if (! Signature::verify($nonce, $request->input('signature'), $request->input('address'))) {
             throw ValidationException::withMessages(['signature' => 'Signature verification failed.']);
         }
     }

--- a/src/Web3LoginServiceProvider.php
+++ b/src/Web3LoginServiceProvider.php
@@ -15,5 +15,13 @@ class Web3LoginServiceProvider extends ServiceProvider
         if (Web3Login::$runsMigrations) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
+
+        $this->publishes([
+            __DIR__.'/../config/web3.php' => config_path('web3.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/web3.php', 'web3'
+        );
     }
 }


### PR DESCRIPTION
This pull request aims to enable user registrarion using only the wallet address. It's been discussed here: https://github.com/m1guelpf/laravel-web3-login/discussions/4

Changes:
- creates a web3.php config file to customize message and enabled routes
- creates a new route named _web3.register that enables user registration
- if the register route is enabled the migration changes user columns to nullable to allow user registration using only the wallet address

